### PR TITLE
Mudança de chamada ao Geopy

### DIFF
--- a/cleaning_tool_app.py
+++ b/cleaning_tool_app.py
@@ -18,6 +18,7 @@ from limpeza_de_dados.create_sidebar import (
     show_selected_row_as_table,
 )
 from limpeza_de_dados.utils import find_new_entries
+from limpeza_de_dados.clean_google_form_data import full_clean_data, CONVERSION, convert_column_names
 
 DRIVE_INFO: dict[str, str] = get_drive_info()
 GC: gspread.client.Client = gspread.authorize(DRIVE_INFO["creds"])
@@ -41,8 +42,10 @@ def load_data_submissions(
     gc: gspread.client.Client = GC,
 ):
     df: pd.DataFrame = read_spreadsheet_as_df(url=url, gc=gc)
-    df = full_clean_data(df_raw=df)
-    return find_new_entries(df_raw=df, df_analysis=df_analysis)
+    df = convert_column_names(df)
+    df_new_sub: pd.DataFrame = find_new_entries(df_raw=df, df_analysis=df_analysis)
+    df_new_sub = df_new_sub.head(20)
+    return full_clean_data(df_raw=df_new_sub)
 
 
 @st.cache_data

--- a/src/limpeza_de_dados/clean_google_form_data.py
+++ b/src/limpeza_de_dados/clean_google_form_data.py
@@ -62,49 +62,30 @@ def convert_column_names(
     df = df.rename(columns=convert_dict)
     return df
 
+def add_detailed_location(row: pd.Series,
+                  geolocator=GEOLOCATOR):
+    row['Freguesia'] = None
+    row['Concelho'] = None
+    row['Distrito'] = None
 
-def add_detailed_location(df: pd.DataFrame, geolocator=GEOLOCATOR):
-    df["Freguesia"] = None
-    df["Concelho"] = None
-    df["Distrito"] = None
-
-    for index, row in df.iterrows():
-        try:
-            freguesia_keys = [
-                "city_district",
-                "village",
-                "suburb",
-                "neighborhood",
-                "neighbourhood",
-                "town",
-                "borough",
-            ]
-            concelho_keys = ["city", "municipality", "town"]
-            distrito_keys = ["county", "state", "region"]
-
-            address = geolocator.reverse((row["Latitude"], row["Longitude"])).raw[
-                "address"
-            ]
-            df.loc[index, "Freguesia"] = next(
-                (address[key] for key in freguesia_keys if key in address), None
-            )
-            df.loc[index, "Concelho"] = next(
-                (address[key] for key in concelho_keys if key in address), None
-            )
-            df.loc[index, "Distrito"] = next(
-                (address[key] for key in distrito_keys if key in address), None
-            )
-        except Exception as e:
-            print("Error adding detailed location:", e)
-            pass
-    return df
+    freguesia_keys = ['city_district', 'village', 'suburb', 'neighborhood', 'neighbourhood', 'town', 'borough']
+    concelho_keys = ['city', 'municipality', 'town']
+    distrito_keys = ['county', 'state', 'region']
+    try:
+        address = geolocator.reverse((row['Latitude'], row['Longitude'])).raw['address']
+        row['Freguesia'] = next((address[key] for key in freguesia_keys if key in address), None)
+        row['Concelho']  = next((address[key] for key in concelho_keys  if key in address), None)
+        row['Distrito']  = next((address[key] for key in distrito_keys  if key in address), None)
+    except:
+        pass
+    return row
 
 
 def convert_datatypes(df: pd.DataFrame):
     if not df.empty:
         df["Data"] = pd.to_datetime(df["Data"], errors="coerce")
-        df["Nº ninhos ocupados"] = df["Altura (andares)"].astype("int")
-        df["Altura (andares)"] = df["Altura (andares)"].astype("int")
+        df['Nº ninhos ocupados'] = df['Nº ninhos ocupados'].astype('Int32')
+        df['Altura (andares)'] = df['Altura (andares)'].astype('Int32')
 
     return df
 
@@ -128,9 +109,7 @@ def add_missing_data_col(df: pd.DataFrame, missing_data_col: str = "Dados em Fal
 
 
 def full_clean_data(df_raw: pd.DataFrame):
-    df = convert_column_names(df_raw)
-    df = split_coordinates(df)
-    df = add_detailed_location(df)
+    df = split_coordinates(df_raw)
     df = convert_datatypes(df)
     df = add_code_col(df)
     df = add_missing_data_col(df)

--- a/src/limpeza_de_dados/create_sidebar.py
+++ b/src/limpeza_de_dados/create_sidebar.py
@@ -53,6 +53,10 @@ from math import asin, cos, radians, sin, sqrt
 
 import pandas as pd
 import streamlit as st
+import pandas as pd
+from math import radians, cos, sin, asin, sqrt
+
+from limpeza_de_dados.clean_google_form_data import add_detailed_location
 
 
 def get_sorted_submission_options(df):
@@ -233,9 +237,8 @@ def get_submission_to_validate(df_new_submissions: pd.DataFrame, n_timestamp_col
         placeholder="Selecciona a submissão",
     )
     selected_id = display_to_id[selected_display]
-    selected_row = df_new_submissions[
-        df_new_submissions[n_timestamp_col] == selected_id
-    ].iloc[0]
+    selected_row = df_new_submissions[df_new_submissions[n_timestamp_col] == selected_id].iloc[0]
+    selected_row = add_detailed_location(selected_row)
 
     return selected_row
 


### PR DESCRIPTION
## Objectivo/Problema
A cleaning tool estava a demorar demasiado tempo durante o loading de submissões do Google Forms devido ao elevado número de chamadas ao geopy.
Geopy estava a ser chamado para todas as submissões do form quer fossem novas ou não.

## Solução
1. Efectuar tarefas de limpeza só sobre o dataset de submissões novas, i.e. submissões do Google Forms que não estão na spreadsheet de submissões validadas (à excepção do Geopy, são funções vectoriais, por isso a melhoria será mínima mas ainda assim...)
2. Chamar Geopy só sobre a submissão a ser analisada: isto garante que não há chamadas recorrentes ao Geopy sem intervenção do utilizador e não há longos períodos de espera

## Como testar
Alterar `RUN_IN_STREAMLIT: bool = True` em src/limpeza_de_dados/create_data_flow_to_google.py
Correr `uv run streamlit run cleaning_tool_app.py` e confirmar que funciona.
